### PR TITLE
fix: edit/foto-url

### DIFF
--- a/src/app/Listados/page.tsx
+++ b/src/app/Listados/page.tsx
@@ -58,40 +58,44 @@ export default function Listings() {
     })
     .slice(0, 10);
 
-  const handleEditSubmit = async (form: FormData) => {
-    if (!selected) return;
-    try {
-      await editarMobiliario(selected.id, {
-        descripcion: form.descripcion,
-        fecha_resolucion: form.fechaResolucion,
-        estado_conservacion: form.estado,
-        comentarios: form.comentarios,
-        resolucion_numero: form.resolucionNumero,
-        resolucion_tipo: form.resolucionTipo,
-      });
-      setMobiliario((prev) =>
-        prev.map((m) =>
-          m.id === selected.id
-            ? {
-                ...m,
-                descripcion: form.descripcion,
-                fecha_resolucion: form.fechaResolucion,
-                estado_conservacion: form.estado,
-                comentarios: form.comentarios,
-                resolucion_numero: form.resolucionNumero,
-                resolucion_tipo: form.resolucionTipo,
-                resolucion: `Resol Nº${form.resolucionNumero} ${form.resolucionTipo}`.trim(),
-              }
-            : m
-        )
-      );
-      setIsEditing(false);
-      setIsModalOpen(false);
-      toast.success("Actualizado correctamente");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Error al editar");
-    }
-  };
+    const handleEditSubmit = async (form: FormData) => {
+      if (!selected) return;
+      try {
+        await editarMobiliario(selected.id, {
+          descripcion: form.descripcion,
+          fecha_resolucion: form.fechaResolucion,
+          estado_conservacion: form.estado,
+          comentarios: form.comentarios,
+          resolucion_numero: form.resolucionNumero,
+          resolucion_tipo: form.resolucionTipo,
+          foto_url: form.foto_url, // ✅ AÑADIDO
+        });
+    
+        setMobiliario((prev) =>
+          prev.map((m) =>
+            m.id === selected.id
+              ? {
+                  ...m,
+                  descripcion: form.descripcion,
+                  fecha_resolucion: form.fechaResolucion,
+                  estado_conservacion: form.estado,
+                  comentarios: form.comentarios,
+                  resolucion_numero: form.resolucionNumero,
+                  resolucion_tipo: form.resolucionTipo,
+                  resolucion: `Resol Nº${form.resolucionNumero} ${form.resolucionTipo}`.trim(),
+                  foto_url: form.foto_url, // ✅ AÑADIDO
+                }
+              : m
+          )
+        );
+    
+        setIsEditing(false);
+        setIsModalOpen(false);
+        toast.success("Actualizado correctamente");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "Error al editar");
+      }
+    };
 
   const handleDelete = async () => {
     if (!selected) return;

--- a/src/services/mobiliarioService.ts
+++ b/src/services/mobiliarioService.ts
@@ -1,5 +1,4 @@
 
-// services/mobiliarioService.ts
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE;
 
 import type { Mobiliario } from "@/types/types";
@@ -17,6 +16,7 @@ export interface MobiliarioUpdate {
   comentarios: string;
   resolucion_numero?: string;
   resolucion_tipo?: string;
+  foto_url?: string; // ✅ AÑADIDO
 }
 
 export const editarMobiliario = async (

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -44,6 +44,7 @@ export interface FormData {
   comentarios: string;
   resolucionNumero: string;
   resolucionTipo: string;
+  foto_url: string;
 }
 
 // --- Shape que devuelve GET /api/mobiliario (ahora con ubicación) ---


### PR DESCRIPTION
## 🛠️ PR: Soporte para edición de imagen en mobiliarios
# Cambios realizados:
* Se agregó la propiedad foto_url a la interfaz FormData para permitir editar la imagen en registros existentes.

* Se actualizó la lógica de Listings.tsx para incluir foto_url al enviar datos al backend mediante editarMobiliario.

* Validación visual: ahora la imagen también se actualiza correctamente al editar un mobiliario.

