### PR TITLE
fix:nuevo-patrimonio

### DIFF
--- a/src/app/patrimonio/nuevo/page.tsx
+++ b/src/app/patrimonio/nuevo/page.tsx
@@ -1,16 +1,13 @@
 
 "use client";
 
-import { useRouter } from "next/navigation";
+import { Wrapper } from "@/components";
 import PatrimonioForm from "@/components/Forms/PatrimonioForm";
 import { createPatrimonio } from "@/services/patrimonioService";
 import { FormularioPatrimonio } from "@/types/types";
 import { toast, Toaster } from "react-hot-toast";
-import { Wrapper } from "@/components";
 
 export default function CrearPatrimonioPage() {
-  const router = useRouter();
-
   const handleSubmit = async (form: FormularioPatrimonio) => {
     try {
       const payload = {
@@ -33,8 +30,7 @@ export default function CrearPatrimonioPage() {
 
       await createPatrimonio(payload);
       toast.success("Registro creado correctamente.");
-      // No redirigimos más
-    } catch (error) {
+    } catch {
       toast.error("Error al crear el mobiliario");
     }
   };
@@ -49,8 +45,8 @@ export default function CrearPatrimonioPage() {
         <PatrimonioForm
           modo="crear"
           onSubmit={handleSubmit}
-          onCancel={() => {}} // ya no redirige
-          resetOnSuccess={true} // limpia el formulario
+          onCancel={() => {}}
+          resetOnSuccess={true}
         />
       </main>
     </Wrapper>


### PR DESCRIPTION
📝 Descripción del PR:
- Se implementó la vista de creación de mobiliario (`/patrimonio/nuevo`) con formulario reutilizable.
- El formulario se limpia automáticamente al crear un registro exitoso.
- Se eliminó la redirección automática post-creación.
- Se agregó botón visible para volver al listado.
- Se corrigió la funcionalidad del Nomenclador para que complete clase y rubro correctamente.
- Se eliminaron imports y variables sin uso para evitar errores de compilación (ESLint).